### PR TITLE
Fix timestamp to use 24 hours instead of 12

### DIFF
--- a/src/leiningen/voom.clj
+++ b/src/leiningen/voom.clj
@@ -70,7 +70,7 @@
 
 ;; === git sha-based versions ===
 
-(def timestamp-fmt "yyyyMMdd_hhmmss")
+(def timestamp-fmt "yyyyMMdd_HHmmss")
 
 (defn formatted-timestamp
   [^String fmt t]


### PR DESCRIPTION
Times would be in 12 hour format without an am/pm marker. Changed to use 24 hour format.
