### PR TITLE
Fix dev repl classpath

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,4 +14,7 @@
                  [org.clojure/test.check "0.6.1"]]
   :signing {:gpg-key "A4D5C342"}
   :repositories [["sonatype-snapshot" "http://oss.sonatype.org/content/repositories/snapshots"]]
-  :eval-in-leiningen true)
+  :eval-in-leiningen true
+  :profiles {:dev {:dependencies [[leiningen-core "2.5.1"]]}
+             :clojure-1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :clojure-1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,6 @@
   :signing {:gpg-key "A4D5C342"}
   :repositories [["sonatype-snapshot" "http://oss.sonatype.org/content/repositories/snapshots"]]
   :eval-in-leiningen true
-  :profiles {:dev {:dependencies [[leiningen-core "2.5.1"]]}
+  :profiles {:leiningen-core-2.5.1 {:dependencies [[leiningen-core "2.5.1"]]}
              :clojure-1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}
              :clojure-1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}})


### PR DESCRIPTION
Adds the following dependencies via profiles:

* :leiningen-core-2.5.1 profile dep on leiningen-core "2.5.1"
* :clojure-1.5 depends on clojure 1.5.0
* :clojure-1.6 depends on clojure 1.6.0
    
Before this change, project.clj does not depend directly on everything necessary to start a REPL. 'lein repl' pulls in all of leiningen's own dependencies and therefore works, but the following does not:
```$ java -cp `lein classpath` clojure.main -r```
```Clojure 1.2.0                 ; <--- note clojure version!```
```user=> (require 'leiningen.voom)```
```;; ...error message related to missing clojure.edn```
    
With these new profiles, the following succeeds:
```$ java -cp `lein with-profile leiningen-core-2.5.1,clojure-1.5 classpath` clojure.main -r```
    
This issue only affects lein-voom development itself, so relegating these dependencies to these profiles should be sufficient.
