### PR TITLE
Updates old core.logic version.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [lonocloud/synthread "1.0.5"]
                  [org.clojure/data.codec "0.1.0"]
                  [org.clojure/data.fressian "0.2.0"]
-                 [org.clojure/core.logic "0.8.5"]
+                 [org.clojure/core.logic "0.8.10"]
                  [org.clojure/test.check "0.6.1"]]
   :plugins [[lein-marginalia "0.8.0"]]
   :signing {:gpg-key "A4D5C342"}


### PR DESCRIPTION
Okay, time to make that terrible warning message go away.