### PR TITLE
Fixes the position of type hints.

### DIFF
--- a/src/leiningen/voom/long_sha.clj
+++ b/src/leiningen/voom/long_sha.clj
@@ -4,10 +4,10 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* true)
 
-(defn ^:private ^long nibbles [^long num]
+(defn ^:private nibbles ^long [^long num]
   (-> num (bit-shift-right 60) (bit-and 0xf)))
 
-(defn ^long mask [^long num]
+(defn mask ^long [^long num]
   (bit-shift-right
    0xfffffffffffffff
    (* 4 (- 15 (nibbles num)))))


### PR DESCRIPTION
This was causing direct linking error messages with Clojure 1.8.0.

cc @abrooks @Chouser 